### PR TITLE
Load contract mapping only if needed

### DIFF
--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -3,7 +3,10 @@ const Web3 = require('web3')
 const { logger } = require('../../lib/logger')
 const constants = require('./lib/constants')
 const { extendEventsWithPrimaryKey } = require('./lib/extend_events_key')
-const { getPastEventsExactContracts } = require('./lib/contract_overwrite')
+let contract_overwrite = null
+if (constants.EXACT_CONTRACT_MODE) {
+  contract_overwrite = require('./lib/contract_overwrite')
+}
 const { getPastEvents } = require('./lib/fetch_events')
 const BaseWorker = require('../../lib/worker_base')
 
@@ -45,7 +48,7 @@ class ERC20Worker extends BaseWorker {
 
     let events = [];
     if (constants.EXACT_CONTRACT_MODE) {
-      events = await getPastEventsExactContracts(this.web3, this.lastExportedBlock + 1, toBlock);
+      events = await contract_overwrite.getPastEventsExactContracts(this.web3, this.lastExportedBlock + 1, toBlock);
     }
     else {
       events = await getPastEvents(this.web3, this.lastExportedBlock + 1, toBlock);

--- a/blockchains/erc20/erc20_worker.js
+++ b/blockchains/erc20/erc20_worker.js
@@ -33,7 +33,7 @@ class ERC20Worker extends BaseWorker {
       const newConfirmedBlock = await this.web3.eth.getBlockNumber() - constants.CONFIRMATIONS
       if (newConfirmedBlock == this.lastConfirmedBlock) {
         // The Node has not progressed
-        return
+        return []
       }
       this.lastConfirmedBlock = newConfirmedBlock
     }


### PR DESCRIPTION
In this PR:
1. Require a contract mapping file only if running in 'exact' mode. Meaning deploys do not need to provide such file if do not use it.
2. Return empty array instead of `null` for consistency.