### PR TITLE
Bugfix. Correct grouping by transaction id.

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 docker build --build-arg NODE_ENV=development -t erc20-transfers-exporter-test -f docker/Dockerfile-test .
-docker run --env BLOCKCHAIN=erc20 --rm -t erc20-transfers-exporter-test
+docker run --env BLOCKCHAIN=erc20 --env LOG_LEVEL=error --rm -t erc20-transfers-exporter-test

--- a/blockchains/erc20/lib/contract_overwrite.js
+++ b/blockchains/erc20/lib/contract_overwrite.js
@@ -29,7 +29,6 @@ class ContractEditor {
 
     logger.info(`Running in 'exact contracts mode', ${this.contractsOverwriteArray.length} contracts will be monitored.`)
     logger.info("Overwritten contracts are:")
-    console.log(JSON.stringify(parsedContracts, null, 4))
   }
 
   editAddressAndAmount(events, contractOverwrite) {

--- a/blockchains/erc20/lib/fetch_events.js
+++ b/blockchains/erc20/lib/fetch_events.js
@@ -245,7 +245,10 @@ function filterEvents(events) {
 // returns an array of arrays - all events in one transaction are grouped together
 // assumes that all events in one transaction are next to one another in the log
 function* getEventsByTransaction(events) {
-  let curTransactionHash = null
+  if (0 == events.length) {
+    return
+  }
+  let curTransactionHash = events[0].transactionHash
   let curTransactionEvents = []
   for (let i = 0;i < events.length; i++) {
     let event = events[i]

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
 const Logger = require('node-json-logger')
-const logger = new Logger()
+const LOG_LEVEL = process.env.LOG_LEVEL || "debug"
+const logger = new Logger({ level: LOG_LEVEL})
 
 module.exports = { logger: logger }

--- a/test/erc20/fetch_events.spec.js
+++ b/test/erc20/fetch_events.spec.js
@@ -382,7 +382,7 @@ describe('getPastEvents', function() {
 describe('getEventsByTransactionTest', function () {
   const getEventsByTransaction = fetch_events.__get__('getEventsByTransaction')
 
-  it("Test that two events for the same transaction would be grouped together", async function() {
+  it("groups together two events for the same transaction", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent1])
     const result = Array.from(iterPerTransaction)
 
@@ -390,7 +390,7 @@ describe('getEventsByTransactionTest', function () {
     assert.deepStrictEqual(result[0], [decodedEvent0, decodedEvent1])
   })
 
-  it("Test that two events for different transactions would be separated together", async function() {
+  it("separates two events from different transactions", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent2])
     const result = Array.from(iterPerTransaction)
 
@@ -399,7 +399,7 @@ describe('getEventsByTransactionTest', function () {
     assert.deepStrictEqual(result[1], [decodedEvent2])
   })
 
-  it("Test that both grouping events and separating works ", async function() {
+  it("ensures grouping and separation of events works properly", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent2, decodedEvent0, decodedEvent1])
     const result = Array.from(iterPerTransaction)
 

--- a/test/erc20/fetch_events.spec.js
+++ b/test/erc20/fetch_events.spec.js
@@ -301,7 +301,44 @@ const filteredEvents = [
     valueExactBase36: '4rgm1aauy6roni8' }
 ]
 
-fetch_events.__set__("getRawEvents", async function (web3, fromBlock, toBlock) {
+const decodedEvent0 = {
+  "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
+  "blockNumber": 5010901,
+  "timestamp": 1517479091,
+  "transactionHash": "0xa32a55989f271a27173a4ec91a4aceadf9cf936a04f84a751d38ac1a816fa1e3",
+  "logIndex": 0,
+  "from": "mint",
+  "to": "0x97623428a891542df710be9589093c9f3d2b60d3",
+  "value": 500000000000000000000,
+  "valueExactBase36": "2xirk7k6w3mt4w"
+}
+
+const decodedEvent1 = {
+  "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
+  "blockNumber": 5010901,
+  "timestamp": 1517479091,
+  "transactionHash": "0xa32a55989f271a27173a4ec91a4aceadf9cf936a04f84a751d38ac1a816fa1e3",
+  "logIndex": 1,
+  "to": "0x97623428a891542df710be9589093c9f3d2b60d3",
+  "from": "0x0000000000000000000000000000000000000000",
+  "value": 500000000000000000000,
+  "valueExactBase36": "2xirk7k6w3mt4w"
+}
+
+const decodedEvent2 = {
+  "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
+    "blockNumber": 5010901,
+    "timestamp": 1517479091,
+    "transactionHash": "0xaab6e97a908f937ffba0690e6ad07053c6a4e822bab08342602204861f66b4b8",
+    "logIndex": 3,
+    "from": "mint",
+    "to": "0xc94698ffa0e74a35707eef8d6f847130c2008df3",
+    "value": 1e+21,
+    "valueExactBase36": "5v1j4f4ds79m9s"
+}
+
+
+fetch_events.__set__("getRawEvents", async function () {
   return rawEvents
 })
 
@@ -339,5 +376,57 @@ describe('getPastEvents', function() {
       result,
       filteredEvents
     )
+  })
+})
+
+describe('getEventsByTransactionTest', function () {
+  const getEventsByTransaction = fetch_events.__get__('getEventsByTransaction')
+
+  it("Test that two events for the same transaction would be grouped together", async function() {
+    const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent1])
+
+    let countElements = 0
+    for (let curTransactionEvents of iterPerTransaction) {
+      if (0 == countElements) {
+        assert.deepStrictEqual(curTransactionEvents, [decodedEvent0, decodedEvent1])
+      }
+      ++countElements
+    }
+
+    assert.strictEqual(1, countElements)
+  })
+
+  it("Test that two events for different transactions would be separated together", async function() {
+    const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent2])
+
+    let countElements = 0
+    for (let curTransactionEvents of iterPerTransaction) {
+      if (0 == countElements) {
+        assert.deepStrictEqual(curTransactionEvents, [decodedEvent0])
+      }
+      else if (1 == countElements) {
+        assert.deepStrictEqual(curTransactionEvents, [decodedEvent2])
+      }
+      ++countElements
+    }
+
+    assert.strictEqual(2, countElements)
+  })
+
+  it("Test that both grouping events and separating works ", async function() {
+    const iterPerTransaction = getEventsByTransaction([decodedEvent2, decodedEvent0, decodedEvent1])
+
+    let countElements = 0
+    for (let curTransactionEvents of iterPerTransaction) {
+      if (0 == countElements) {
+        assert.deepStrictEqual(curTransactionEvents, [decodedEvent2])
+      }
+      else if (1 == countElements) {
+        assert.deepStrictEqual(curTransactionEvents, [decodedEvent0, decodedEvent1])
+      }
+      ++countElements
+    }
+
+    assert.strictEqual(2, countElements)
   })
 })

--- a/test/erc20/fetch_events.spec.js
+++ b/test/erc20/fetch_events.spec.js
@@ -384,49 +384,27 @@ describe('getEventsByTransactionTest', function () {
 
   it("Test that two events for the same transaction would be grouped together", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent1])
+    const result = Array.from(iterPerTransaction)
 
-    let countElements = 0
-    for (let curTransactionEvents of iterPerTransaction) {
-      if (0 == countElements) {
-        assert.deepStrictEqual(curTransactionEvents, [decodedEvent0, decodedEvent1])
-      }
-      ++countElements
-    }
-
-    assert.strictEqual(1, countElements)
+    assert.strictEqual(1, result.length)
+    assert.deepStrictEqual(result[0], [decodedEvent0, decodedEvent1])
   })
 
   it("Test that two events for different transactions would be separated together", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent2])
+    const result = Array.from(iterPerTransaction)
 
-    let countElements = 0
-    for (let curTransactionEvents of iterPerTransaction) {
-      if (0 == countElements) {
-        assert.deepStrictEqual(curTransactionEvents, [decodedEvent0])
-      }
-      else if (1 == countElements) {
-        assert.deepStrictEqual(curTransactionEvents, [decodedEvent2])
-      }
-      ++countElements
-    }
-
-    assert.strictEqual(2, countElements)
+    assert.strictEqual(2, result.length)
+    assert.deepStrictEqual(result[0], [decodedEvent0])
+    assert.deepStrictEqual(result[1], [decodedEvent2])
   })
 
   it("Test that both grouping events and separating works ", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent2, decodedEvent0, decodedEvent1])
+    const result = Array.from(iterPerTransaction)
 
-    let countElements = 0
-    for (let curTransactionEvents of iterPerTransaction) {
-      if (0 == countElements) {
-        assert.deepStrictEqual(curTransactionEvents, [decodedEvent2])
-      }
-      else if (1 == countElements) {
-        assert.deepStrictEqual(curTransactionEvents, [decodedEvent0, decodedEvent1])
-      }
-      ++countElements
-    }
-
-    assert.strictEqual(2, countElements)
+    assert.strictEqual(2, result.length)
+    assert.deepStrictEqual(result[0], [decodedEvent2])
+    assert.deepStrictEqual(result[1], [decodedEvent0, decodedEvent1])
   })
 })

--- a/test/erc20/fetch_events.spec.js
+++ b/test/erc20/fetch_events.spec.js
@@ -301,43 +301,6 @@ const filteredEvents = [
     valueExactBase36: '4rgm1aauy6roni8' }
 ]
 
-const decodedEvent0 = {
-  "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
-  "blockNumber": 5010901,
-  "timestamp": 1517479091,
-  "transactionHash": "0xa32a55989f271a27173a4ec91a4aceadf9cf936a04f84a751d38ac1a816fa1e3",
-  "logIndex": 0,
-  "from": "mint",
-  "to": "0x97623428a891542df710be9589093c9f3d2b60d3",
-  "value": 500000000000000000000,
-  "valueExactBase36": "2xirk7k6w3mt4w"
-}
-
-const decodedEvent1 = {
-  "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
-  "blockNumber": 5010901,
-  "timestamp": 1517479091,
-  "transactionHash": "0xa32a55989f271a27173a4ec91a4aceadf9cf936a04f84a751d38ac1a816fa1e3",
-  "logIndex": 1,
-  "to": "0x97623428a891542df710be9589093c9f3d2b60d3",
-  "from": "0x0000000000000000000000000000000000000000",
-  "value": 500000000000000000000,
-  "valueExactBase36": "2xirk7k6w3mt4w"
-}
-
-const decodedEvent2 = {
-  "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
-    "blockNumber": 5010901,
-    "timestamp": 1517479091,
-    "transactionHash": "0xaab6e97a908f937ffba0690e6ad07053c6a4e822bab08342602204861f66b4b8",
-    "logIndex": 3,
-    "from": "mint",
-    "to": "0xc94698ffa0e74a35707eef8d6f847130c2008df3",
-    "value": 1e+21,
-    "valueExactBase36": "5v1j4f4ds79m9s"
-}
-
-
 fetch_events.__set__("getRawEvents", async function () {
   return rawEvents
 })
@@ -381,6 +344,42 @@ describe('getPastEvents', function() {
 
 describe('getEventsByTransactionTest', function () {
   const getEventsByTransaction = fetch_events.__get__('getEventsByTransaction')
+
+  const decodedEvent0 = {
+    "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
+    "blockNumber": 5010901,
+    "timestamp": 1517479091,
+    "transactionHash": "0xa32a55989f271a27173a4ec91a4aceadf9cf936a04f84a751d38ac1a816fa1e3",
+    "logIndex": 0,
+    "from": "mint",
+    "to": "0x97623428a891542df710be9589093c9f3d2b60d3",
+    "value": 500000000000000000000,
+    "valueExactBase36": "2xirk7k6w3mt4w"
+  }
+
+  const decodedEvent1 = {
+    "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
+    "blockNumber": 5010901,
+    "timestamp": 1517479091,
+    "transactionHash": "0xa32a55989f271a27173a4ec91a4aceadf9cf936a04f84a751d38ac1a816fa1e3",
+    "logIndex": 1,
+    "to": "0x97623428a891542df710be9589093c9f3d2b60d3",
+    "from": "0x0000000000000000000000000000000000000000",
+    "value": 500000000000000000000,
+    "valueExactBase36": "2xirk7k6w3mt4w"
+  }
+
+  const decodedEvent2 = {
+    "contract": "0xeb9951021698b42e4399f9cbb6267aa35f82d59d",
+    "blockNumber": 5010901,
+    "timestamp": 1517479091,
+    "transactionHash": "0xaab6e97a908f937ffba0690e6ad07053c6a4e822bab08342602204861f66b4b8",
+    "logIndex": 3,
+    "from": "mint",
+    "to": "0xc94698ffa0e74a35707eef8d6f847130c2008df3",
+    "value": 1e+21,
+    "valueExactBase36": "5v1j4f4ds79m9s"
+  }
 
   it("groups together two events for the same transaction", async function() {
     const iterPerTransaction = getEventsByTransaction([decodedEvent0, decodedEvent1])


### PR DESCRIPTION
This PR fixes a long lasting bug, reported in this ticket:
https://www.notion.so/santiment/Fix-bug-in-the-handling-of-Mint-Transfer-events-in-erc20-exporter-6b8ccee5f75845eb91098ee2247a6e3d

The bug presented itself as both Mint transactions and transfers from '0x0000...' being present even though we have a logic for filtering and leaving only one of the two. After investigation it turned out that the issue is due to an utility function bug. The utility function is supposed to break an array of decoded events into arrays, where events for same transaction are present in the same array. This does not happen correctly when the events for the same transaction are at the start. Tests added illustrating the problem. 